### PR TITLE
feat(cluster): Support customizing maximum grpc message size

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -63,7 +63,13 @@ type cluster struct {
 }
 
 func OpenRemote(clusterState coordinator.Coordinator, opt Options) (Cluster, error) {
-	var grpcOpts []grpc.DialOption
+	grpcOpts := []grpc.DialOption{
+		grpc.WithBlock(),
+		grpc.WithDefaultCallOptions(
+			grpc.MaxCallRecvMsgSize(opt.MaxMessageSize),
+			grpc.MaxCallSendMsgSize(opt.MaxMessageSize),
+		),
+	}
 	if opt.TLSCertPath != "" {
 		cert, err := credentials.NewClientTLSFromFile(opt.TLSCertPath, opt.TLSCertServerName)
 		if err != nil {
@@ -74,7 +80,6 @@ func OpenRemote(clusterState coordinator.Coordinator, opt Options) (Cluster, err
 		// log.Warn("inter-node RPC is in insecure mode. we recommend configuring TLS credentials.")
 		grpcOpts = append(grpcOpts, grpc.WithInsecure())
 	}
-	grpcOpts = append(grpcOpts, grpc.WithBlock())
 
 	ctx, cancel := context.WithCancel(context.Background())
 	return &cluster{

--- a/cluster/options.go
+++ b/cluster/options.go
@@ -9,6 +9,10 @@ import (
 type Options struct {
 	ConnectTimeout time.Duration `default:"3s"`
 
+	// MaxMessageSize specifies the maximum message size in bytes the gRPC client can receive/send.
+	// The default value is 500mb.
+	MaxMessageSize int `default:"524288000"`
+
 	// LivenessProbeInterval specifies interval for notifying this node's liveness to other nodes.
 	// If a liveness probe fails, the node would not be visible until the next tick of the liveness probe.
 	LivenessProbeInterval time.Duration `default:"10s"`


### PR DESCRIPTION
- This change makes lrmr clsuter support customizable option for maximum gRPC message size and changes its default value to 500mb.