### PR TITLE
fix: Split TestLocalMemoryCoordinator_GrantLease to RetrieveWithinTTL and RetrievedAfterTTL

### DIFF
--- a/cluster/cluster_test.go
+++ b/cluster/cluster_test.go
@@ -184,7 +184,9 @@ func WithTestNodes(cluster cluster.Cluster, fn func(nodes []node.Registration)) 
 			servers[i] = grpc.NewServer()
 			go func(i int) {
 				err := servers[i].Serve(lis)
-				c.So(err, ShouldBeNil)
+				if err != nil {
+					panic(err)
+				}
 			}(i)
 
 			n := &node.Node{

--- a/coordinator/local_memory_test.go
+++ b/coordinator/local_memory_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLocalMemoryCoordinator_Get(t *testing.T) {
@@ -110,34 +111,50 @@ func TestLocalMemoryCoordinator_CAS(t *testing.T) {
 	})
 }
 
-func TestLocalMemoryCoordinator_GrantLease(t *testing.T) {
-	// This test relies on TTL timeout. If the test machine is not fast enough(like GitHub actions, ...), it will fail.
-	// Maybe we should consider deleting this test.
+func TestLocalMemoryCoordinator_GrantLease_RetrievedWithinTTL(t *testing.T) {
+	crd := NewLocalMemory()
+	ctx := gocontext.Background()
 
-	Convey("Given LocalMemoryCoordinator", t, func() {
-		crd := NewLocalMemory()
-		ctx := gocontext.Background()
+	l, err := crd.GrantLease(ctx, 10*time.Second)
+	require.Nil(t, err)
 
-		l, err := crd.GrantLease(ctx, 2*time.Second)
-		So(err, ShouldBeNil)
+	testKey1 := "testKey1"
+	testKey2 := "testKey2"
 
-		So(crd.Put(ctx, "testKey1", "testValue1", WithLease(l)), ShouldBeNil)
-		So(crd.Put(ctx, "testKey2", "testValue1", WithLease(l)), ShouldBeNil)
+	err = crd.Put(ctx, testKey1, "testValue1", WithLease(l))
+	require.Nil(t, err)
 
-		Convey("It should be retrieved within TTL", func() {
-			items, err := crd.Scan(ctx, "testKey")
-			So(err, ShouldBeNil)
+	err = crd.Put(ctx, testKey2, "testValue1", WithLease(l))
+	require.Nil(t, err)
 
-			So(items, ShouldHaveLength, 2)
-			So(items[0].Key, ShouldEqual, "testKey1")
-			So(items[1].Key, ShouldEqual, "testKey2")
-		})
+	items, err := crd.Scan(ctx, "testKey")
+	require.Nil(t, err)
 
-		Convey("It should be deleted after TTL", func() {
-			time.Sleep(3 * time.Second)
-			items, err := crd.Scan(ctx, "testKey")
-			So(err, ShouldBeNil)
-			So(items, ShouldHaveLength, 0)
-		})
-	})
+	require.Equal(t, 2, len(items))
+
+	require.Equal(t, testKey1, items[0].Key)
+	require.Equal(t, testKey2, items[1].Key)
+}
+
+func TestLocalMemoryCoordinator_GrantLease_RetrievedAfterTTL(t *testing.T) {
+	crd := NewLocalMemory()
+	ctx := gocontext.Background()
+
+	l, err := crd.GrantLease(ctx, 1*time.Millisecond)
+	require.Nil(t, err)
+
+	testKey1 := "testKey1"
+	testKey2 := "testKey2"
+
+	err = crd.Put(ctx, testKey1, "testValue1", WithLease(l))
+	require.Nil(t, err)
+
+	err = crd.Put(ctx, testKey2, "testValue1", WithLease(l))
+	require.Nil(t, err)
+
+	time.Sleep(500 * time.Millisecond)
+	items, err := crd.Scan(ctx, "testKey")
+	require.Nil(t, err)
+
+	require.Equal(t, 0, len(items))
 }


### PR DESCRIPTION
Before doing this, tests sometimes failed because I couldn't set a proper timeout value.