### PR TITLE
feat(driver): Make Driver.RunAttached return result as channel from slice

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,3 +39,12 @@ mocks: deps
 
 test:
 	go test ./...
+
+vet:
+	go vet ./...
+
+sec:
+	gosec ./...
+
+pre-push: test vet sec
+

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -8,30 +8,25 @@ import (
 
 	"github.com/ab180/lrmr/cluster"
 	"github.com/ab180/lrmr/input"
-	"github.com/ab180/lrmr/internal/errchannel"
 	"github.com/ab180/lrmr/internal/errgroup"
 	"github.com/ab180/lrmr/internal/pbtypes"
 	"github.com/ab180/lrmr/internal/serialization"
 	"github.com/ab180/lrmr/job"
 	"github.com/ab180/lrmr/lrdd"
 	"github.com/ab180/lrmr/lrmrpb"
-	"github.com/ab180/lrmr/metric"
 	"github.com/ab180/lrmr/output"
+	"github.com/airbloc/logger"
 	"github.com/pkg/errors"
 	"github.com/therne/errorist"
-	"go.uber.org/atomic"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
-type Driver interface {
-	RunAttached(context.Context) (*CollectResult, error)
-	RunDetached(context.Context) error
-}
+var log = logger.New("lrmr.driver")
 
-type CollectResult struct {
-	Outputs []*lrdd.Row
-	Metrics lrmrmetric.Metrics
+type Driver interface {
+	RunAttached(context.Context) (Result, error)
+	RunDetached(context.Context) error
 }
 
 type Remote struct {
@@ -40,9 +35,27 @@ type Remote struct {
 	Connections map[string]lrmrpb.NodeClient
 	Input       input.Feeder
 	Broadcast   serialization.Broadcast
+	rowChanLen  int
 }
 
-func NewRemote(ctx context.Context, j *job.Job, c cluster.Cluster, in input.Feeder, broadcasts serialization.Broadcast) (Driver, error) {
+func NewRemote(
+	ctx context.Context,
+	j *job.Job,
+	c cluster.Cluster,
+	in input.Feeder,
+	broadcasts serialization.Broadcast,
+	options ...func(*Remote),
+) (Driver, error) {
+	drv := &Remote{
+		Job:       j,
+		Cluster:   c,
+		Input:     in,
+		Broadcast: broadcasts,
+	}
+	for _, o := range options {
+		o(drv)
+	}
+
 	var (
 		conns = make(map[string]lrmrpb.NodeClient)
 		mu    sync.Mutex
@@ -64,162 +77,114 @@ func NewRemote(ctx context.Context, j *job.Job, c cluster.Cluster, in input.Feed
 	if err := wg.Wait(); err != nil {
 		return nil, err
 	}
-	return &Remote{
-		Job:         j,
-		Cluster:     c,
-		Connections: conns,
-		Input:       in,
-		Broadcast:   broadcasts,
-	}, nil
+
+	drv.Connections = conns
+	return drv, nil
 }
 
-func (m *Remote) RunAttached(ctx context.Context) (*CollectResult, error) {
-	ctx, cancel := context.WithCancel(ctx)
+func (m *Remote) RunAttached(ctx context.Context) (Result, error) {
+	syncCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
 	// 1. create the job in executors
-	if err := m.createJob(ctx); err != nil {
+	if err := m.createJob(syncCtx); err != nil {
 		return nil, errors.Wrap(err, "create job")
 	}
 
-	// 2. start job and connect streams
-	var (
-		streams = make(map[string]lrmrpb.Node_StartJobInForegroundClient)
-		mu      sync.Mutex
-		wg      errgroup.Group
-	)
-	for host, rpc := range m.Connections {
-		host, rpc := host, rpc
+	asyncCtx, asyncCtxCancel := context.WithCancel(ctx)
 
-		wg.Go(func() error {
+	res := &result{
+		rowChan:    make(chan *lrdd.Row, m.rowChanLen),
+		jobManager: job.NewLocalManager(m.Job),
+		cancel:     asyncCtxCancel,
+	}
+
+	res.jobManager.OnJobCompletion(func(s *job.Status) {
+		for _, err := range s.Errors {
+			res.addErr(err)
+		}
+
+		asyncCtxCancel()
+	})
+
+	// 2. async start jobs and connect streams
+	var wg sync.WaitGroup
+	for host, rpc := range m.Connections {
+		wg.Add(1)
+
+		go func(host string, rpc lrmrpb.NodeClient) {
+			defer func() {
+				if err := errorist.WrapPanic(recover()); err != nil {
+					res.addErr(err)
+				}
+
+				wg.Done()
+			}()
+
 			req := &lrmrpb.StartJobRequest{
 				JobID: m.Job.ID,
 			}
-			stream, err := rpc.StartJobInForeground(ctx, req)
+			stream, err := rpc.StartJobInForeground(asyncCtx, req)
 			if err != nil {
-				return errors.Wrapf(err, "call StartJobInForeground to %s", host)
+				res.addErr(errors.Wrapf(err, "call StartJobInForeground to %s", host))
+				return
 			}
-			mu.Lock()
-			streams[host] = stream
-			mu.Unlock()
-			return nil
-		})
-	}
-	// 2.1. feed inputs simultaneously
-	wg.Go(func() error {
-		return m.feedInput(ctx, m.Job, m.Input)
-	})
-	if err := wg.Wait(); err != nil {
-		return nil, err
-	}
-	defer func() {
-		for _, stream := range streams {
-			_ = stream.CloseSend()
-		}
-	}()
 
-	// 3.1. monitor status
-	// we use error channel for centralized lifecycle management
-	var (
-		activeStreamCnt = atomic.NewInt32(0)
-		errChan         = errchannel.New()
-		statusChan      = make(chan *lrmrpb.JobOutput)
-	)
-	defer errChan.Close()
-
-	for host, stream := range streams {
-		host, stream := host, stream
-		activeStreamCnt.Add(1)
-		go func() {
-			defer func() {
-				if err := errorist.WrapPanic(recover()); err != nil {
-					errChan.Send(err)
-				}
-				cnt := activeStreamCnt.Dec()
-				if cnt == 0 {
-					close(statusChan)
-				}
-			}()
-
-			for ctx.Err() == nil {
+			for asyncCtx.Err() == nil {
 				msg, err := stream.Recv()
 				if err != nil {
 					if err == io.EOF || status.Code(err) == codes.Canceled || errors.Is(err, context.Canceled) {
-						return
+						// normal end of stream
+					} else if status.Code(err) == codes.DeadlineExceeded {
+						res.addErr(context.DeadlineExceeded)
+					} else {
+						res.addErr(errors.Wrapf(err, "receive status from %s", host))
 					}
-					if status.Code(err) == codes.DeadlineExceeded {
-						errChan.Send(context.DeadlineExceeded)
-						return
+					break
+				}
+
+				// received status report message from executor node
+				if msg.Type == lrmrpb.JobOutput_COLLECT_DATA {
+					for _, row := range msg.Data {
+						res.rowChan <- row
 					}
-					errChan.Send(errors.Wrapf(err, "receive status from %s", host))
-					return
-				}
-				if activeStreamCnt.Load() > 0 {
-					statusChan <- msg
+				} else if msg.Type == lrmrpb.JobOutput_REPORT_TASK_COMPLETION {
+					taskID := job.TaskID{
+						JobID:       m.Job.ID,
+						StageName:   msg.Stage,
+						PartitionID: msg.PartitionID,
+					}
+					switch msg.TaskStatus {
+					case lrmrpb.JobOutput_SUCCEED:
+						_ = res.jobManager.MarkTaskAsSucceed(asyncCtx, taskID, msg.Metrics)
+					case lrmrpb.JobOutput_FAILED:
+						_ = res.jobManager.MarkTaskAsFailed(asyncCtx, taskID, errors.New(msg.Error), msg.Metrics)
+					default:
+						log.Warn("unexpected task status. [task_id: {}, status: {}]", taskID, msg.TaskStatus)
+					}
 				}
 			}
-		}()
-	}
 
-	// 3.2. handle status
-	jobMgr := job.NewLocalManager(m.Job)
-	jobMgr.OnJobCompletion(func(s *job.Status) {
-		if len(s.Errors) > 0 {
-			errChan.Send(s.Errors[0])
-			return
-		}
-		errChan.Send(nil)
-	})
-
-	var result []*lrdd.Row
-JobRun:
-	// 4. consume status stream
-	for {
-		select {
-		// 4.1. received status report message from executor node
-		case msg := <-statusChan:
-			if msg == nil {
-				// channel is closed before job completion
-				continue
-			}
-			switch msg.Type {
-			case lrmrpb.JobOutput_COLLECT_DATA:
-				result = append(result, msg.Data...)
-
-			case lrmrpb.JobOutput_REPORT_TASK_COMPLETION:
-				taskID := job.TaskID{
-					JobID:       m.Job.ID,
-					StageName:   msg.Stage,
-					PartitionID: msg.PartitionID,
-				}
-				if msg.TaskStatus == lrmrpb.JobOutput_FAILED {
-					_ = jobMgr.MarkTaskAsFailed(ctx, taskID, errors.New(msg.Error), msg.Metrics)
-					continue
-				}
-				_ = jobMgr.MarkTaskAsSucceed(ctx, taskID, msg.Metrics)
-			}
-
-		// 4.2. job is completed (success when err == nil)
-		case err := <-errChan.Recv():
+			err = stream.CloseSend()
 			if err != nil {
-				return nil, err
+				res.addErr(errors.Wrapf(err, "close stream to %s", host))
 			}
-			break JobRun
+		}(host, rpc)
+	}
 
-		// 4.3. context cancelled
-		case <-ctx.Done():
-			// at the moment, the job is already cancelled since RunJob stream is bound to ctx
-			return nil, ctx.Err()
-		}
-	}
-	metrics, err := jobMgr.CollectMetrics(ctx)
+	go func() {
+		wg.Wait()
+
+		close(res.rowChan)
+	}()
+
+	// 3. feed inputs simultaneously
+	err := m.feedInput(syncCtx, m.Job, m.Input)
 	if err != nil {
-		return nil, errors.Wrap(err, "collect metrics")
+		return nil, err
 	}
-	return &CollectResult{
-		Outputs: result,
-		Metrics: metrics,
-	}, nil
+
+	return res, nil
 }
 
 func (m *Remote) RunDetached(ctx context.Context) error {
@@ -252,6 +217,13 @@ func (m *Remote) RunDetached(ctx context.Context) error {
 		return errors.Wrap(err, "feed input")
 	}
 	return nil
+}
+
+// WithRowChanLen sets the length of the channel for receiving rows.
+func WithRowChanLen(rowChanLen int) func(*Remote) {
+	return func(r *Remote) {
+		r.rowChanLen = rowChanLen
+	}
 }
 
 func (m *Remote) createJob(ctx context.Context) error {

--- a/driver/result.go
+++ b/driver/result.go
@@ -1,0 +1,72 @@
+package driver
+
+import (
+	"context"
+	"sync"
+
+	"github.com/ab180/lrmr/job"
+	"github.com/ab180/lrmr/lrdd"
+	lrmrmetric "github.com/ab180/lrmr/metric"
+	"github.com/hashicorp/go-multierror"
+)
+
+// Result is the interface that result of a driver run.
+//
+// Outputs returns a channel that will yield rows.
+// Metrics returns the metrics for the job.
+// Err returns the error that occurred during the run.
+// Cancel cancels the run.
+type Result interface {
+	Outputs() <-chan *lrdd.Row
+	Metrics() (lrmrmetric.Metrics, error)
+	Err() error
+	Cancel()
+}
+
+type result struct {
+	rowChan    chan *lrdd.Row
+	err        *multierror.Error
+	jobManager job.Manager
+	mux        sync.Mutex
+	cancel     context.CancelFunc
+}
+
+// Outputs returns the output row channel of the job.
+func (r *result) Outputs() <-chan *lrdd.Row {
+	return r.rowChan
+}
+
+// Metrics returns the metrics of the job.
+func (r *result) Metrics() (lrmrmetric.Metrics, error) {
+	return r.jobManager.CollectMetrics(context.Background())
+}
+
+// Err returns the error of the job.
+func (r *result) Err() error {
+	// Flush remaining rows.
+	for _ = range r.rowChan {
+	}
+
+	if r.err.ErrorOrNil() == nil {
+		return nil
+	}
+
+	newErr := &multierror.Error{
+		Errors: make([]error, len(r.err.Errors)),
+	}
+	copy(newErr.Errors, r.err.Errors)
+
+	return newErr
+}
+
+// Cancel cancels the job.
+func (r *result) Cancel() {
+	r.cancel()
+}
+
+func (r *result) addErr(err error) {
+	r.mux.Lock()
+	defer r.mux.Unlock()
+
+	r.err = multierror.Append(r.err, err)
+}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/airbloc/logger v1.4.7
 	github.com/creasty/defaults v1.3.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.2.2
+	github.com/hashicorp/go-multierror v1.1.1
 	github.com/jinzhu/copier v0.0.0-20190924061706-b57f9002281a
 	github.com/json-iterator/go v1.1.12
 	github.com/modern-go/reflect2 v1.0.2
@@ -25,6 +26,7 @@ require (
 	go.uber.org/atomic v1.7.0
 	go.uber.org/goleak v1.1.10
 	go.uber.org/zap v1.17.0
+	golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f
 	golang.org/x/sys v0.0.0-20211019181941-9d821ace8654
 	google.golang.org/grpc v1.38.0
 	google.golang.org/protobuf v1.26.0
@@ -40,6 +42,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 // indirect
+	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/jtolds/gls v4.20.0+incompatible // indirect
 	github.com/maruel/panicparse v1.5.0 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
@@ -53,7 +56,6 @@ require (
 	go.uber.org/multierr v1.6.0 // indirect
 	golang.org/x/exp v0.0.0-20220613132600-b0d781184e0d // indirect
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 // indirect
-	golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/tools v0.1.10 // indirect
 	google.golang.org/genproto v0.0.0-20210602131652-f16073e35f0c // indirect

--- a/go.sum
+++ b/go.sum
@@ -87,6 +87,10 @@ github.com/grpc-ecosystem/go-grpc-middleware v1.2.2 h1:FlFbCRLd5Jr4iYXZufAvgWN6A
 github.com/grpc-ecosystem/go-grpc-middleware v1.2.2/go.mod h1:EaizFBKfUKtMIF5iaDEhniwNedqGo9FuLFzppDr3uwI=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
+github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
+github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/jinzhu/copier v0.0.0-20190924061706-b57f9002281a h1:zPPuIq2jAWWPTrGt70eK/BSch+gFAGrNzecsoENgu2o=
 github.com/jinzhu/copier v0.0.0-20190924061706-b57f9002281a/go.mod h1:yL958EeXv8Ylng6IfnvG4oflryUi3vgA3xPs9hmII1s=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=

--- a/job/manager_local.go
+++ b/job/manager_local.go
@@ -86,6 +86,9 @@ func (l *LocalManager) markJobAsSucceed() {
 }
 
 func (l *LocalManager) MarkTaskAsFailed(_ context.Context, causedTask TaskID, err error, metrics lrmrmetric.Metrics) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
 	l.mergeTaskMetricsIntoJobMetrics(metrics)
 	log.Verbose("Job {} failed", l.job.ID)
 

--- a/pipeline.go
+++ b/pipeline.go
@@ -161,7 +161,14 @@ func (p *Pipeline) RunInBackground(c cluster.Cluster) (*RunningJob, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "create job")
 	}
-	drv, err := driver.NewRemote(ctx, j, c, p.input, p.broadcasts)
+	drv, err := driver.NewRemote(
+		ctx,
+		j,
+		c,
+		p.input,
+		p.broadcasts,
+		driver.WithRowChanLen(0), // TODO: control with clust options
+	)
 	if err != nil {
 		return nil, errors.Wrap(err, "initiate job driver")
 	}
@@ -172,7 +179,7 @@ func (p *Pipeline) RunInBackground(c cluster.Cluster) (*RunningJob, error) {
 	return runningJob, nil
 }
 
-func (p *Pipeline) RunAndCollect(ctx context.Context, c cluster.Cluster) (*driver.CollectResult, error) {
+func (p *Pipeline) RunAndCollect(ctx context.Context, c cluster.Cluster) (driver.Result, error) {
 	j, err := p.createJob(ctx, c)
 	if err != nil {
 		return nil, errors.Wrap(err, "create job")
@@ -181,7 +188,14 @@ func (p *Pipeline) RunAndCollect(ctx context.Context, c cluster.Cluster) (*drive
 		Stage:       executor.CollectStageName,
 		Partitioner: partitions.WrapPartitioner(partitions.NewPreservePartitioner()),
 	}
-	drv, err := driver.NewRemote(context.Background(), j, c, p.input, p.broadcasts)
+	drv, err := driver.NewRemote(
+		context.Background(),
+		j,
+		c,
+		p.input,
+		p.broadcasts,
+		driver.WithRowChanLen(0), // TODO: control with clust options
+	)
 	if err != nil {
 		return nil, errors.Wrap(err, "initiate job driver")
 	}

--- a/test/broadcast_test.go
+++ b/test/broadcast_test.go
@@ -3,6 +3,7 @@ package test
 import (
 	"testing"
 
+	"github.com/ab180/lrmr/lrdd"
 	"github.com/ab180/lrmr/test/integration"
 	"github.com/ab180/lrmr/test/testutils"
 	. "github.com/smartystreets/goconvey/convey"
@@ -14,10 +15,18 @@ func TestBroadcast(t *testing.T) {
 			ds := BroadcastTester()
 
 			Convey("It should run without preserving broadcast values from master", func() {
-				rows, err := ds.RunAndCollect(testutils.ContextWithTimeout(), cluster)
+				result, err := ds.RunAndCollect(testutils.ContextWithTimeout(), cluster)
 				So(err, ShouldBeNil)
-				So(rows.Outputs, ShouldHaveLength, 1)
-				So(testutils.StringValue(rows.Outputs[0]), ShouldEqual, "throughStruct=foo, throughContext=bar, typeMatched=true")
+
+				var rows []*lrdd.Row
+				for row := range result.Outputs() {
+					rows = append(rows, row)
+				}
+				err = result.Err()
+				So(err, ShouldBeNil)
+
+				So(rows, ShouldHaveLength, 1)
+				So(testutils.StringValue(rows[0]), ShouldEqual, "throughStruct=foo, throughContext=bar, typeMatched=true")
 			})
 		})
 	}))

--- a/test/context_cancel_test.go
+++ b/test/context_cancel_test.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -20,8 +21,13 @@ func TestContextCancel(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 			defer cancel()
 
-			_, err := ds.RunAndCollect(ctx, cluster)
-			So(err, ShouldBeError, context.DeadlineExceeded)
+			result, err := ds.RunAndCollect(ctx, cluster)
+			So(err, ShouldBeNil)
+
+			err = result.Err()
+			if !errors.Is(err, context.DeadlineExceeded) {
+				t.Errorf("Expected DeadlineExceeded, got %v", err)
+			}
 
 			time.Sleep(500 * time.Millisecond)
 			So(canceled.Load(), ShouldBeTrue)
@@ -39,8 +45,13 @@ func TestContextCancel_WithinForLoop(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 			defer cancel()
 
-			_, err := ds.RunAndCollect(ctx, cluster)
-			So(err, ShouldBeError, context.DeadlineExceeded)
+			result, err := ds.RunAndCollect(ctx, cluster)
+			So(err, ShouldBeNil)
+
+			err = result.Err()
+			if !errors.Is(err, context.DeadlineExceeded) {
+				t.Errorf("Expected DeadlineExceeded, got %v", err)
+			}
 		})
 	}))
 }
@@ -55,8 +66,13 @@ func TestContextCancel_WithLocalPipes(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 			defer cancel()
 
-			_, err := ds.RunAndCollect(ctx, cluster)
-			So(err, ShouldBeError, context.DeadlineExceeded)
+			result, err := ds.RunAndCollect(ctx, cluster)
+			So(err, ShouldBeNil)
+
+			err = result.Err()
+			if !errors.Is(err, context.DeadlineExceeded) {
+				t.Errorf("Expected DeadlineExceeded, got %v", err)
+			}
 		})
 	}))
 }

--- a/test/custom_partitioner_test.go
+++ b/test/custom_partitioner_test.go
@@ -17,7 +17,10 @@ func TestCustomPartitioner(t *testing.T) {
 				result, err := ds.RunAndCollect(testutils.ContextWithTimeout(), cluster)
 				So(err, ShouldBeNil)
 
-				res := testutils.GroupRowsByKey(result.Outputs)
+				res := testutils.GroupRowsByKey(result.Outputs())
+				err = result.Err()
+				So(err, ShouldBeNil)
+
 				So(res, ShouldHaveLength, 2)
 				So(res["1"], ShouldHaveLength, 2)
 				So(res["2"], ShouldHaveLength, 2)

--- a/test/failing_job_test.go
+++ b/test/failing_job_test.go
@@ -22,8 +22,12 @@ func TestFailingJob(t *testing.T) {
 			So(err, ShouldNotBeNil)
 		})
 		Convey("It should handle errors gracefully on Collect", func() {
-			_, err := ds.RunAndCollect(testutils.ContextWithTimeout(), cluster)
-			So(err, ShouldNotBeNil)
+			result, err := ds.RunAndCollect(testutils.ContextWithTimeout(), cluster)
+
+			if err == nil {
+				err = result.Err()
+				So(err, ShouldNotBeNil)
+			}
 		})
 	}))
 }
@@ -44,8 +48,12 @@ func TestFailingJob_WithFatalErrors(t *testing.T) {
 		Convey("It should handle errors gracefully on Collect", func() {
 			go forceKillWorker(cluster.Executors[0])
 
-			_, err := ds.RunAndCollect(testutils.ContextWithTimeout(), cluster)
-			So(err, ShouldNotBeNil)
+			result, err := ds.RunAndCollect(testutils.ContextWithTimeout(), cluster)
+
+			if err == nil {
+				err = result.Err()
+				So(err, ShouldNotBeNil)
+			}
 		})
 	}))
 }

--- a/test/flatmap_test.go
+++ b/test/flatmap_test.go
@@ -14,17 +14,19 @@ func TestFlatMap(t *testing.T) {
 			ds := FlatMap()
 
 			Convey("It should run without error", func() {
-				rows, err := ds.RunAndCollect(testutils.ContextWithTimeout(), cluster)
+				res, err := ds.RunAndCollect(testutils.ContextWithTimeout(), cluster)
 				So(err, ShouldBeNil)
-				So(rows.Outputs, ShouldHaveLength, 8000)
 
 				max := 0
-				for _, row := range rows.Outputs {
+				for row := range res.Outputs() {
 					n := testutils.IntValue(row)
 					if n > max {
 						max = n
 					}
 				}
+				err = res.Err()
+				So(err, ShouldBeNil)
+
 				So(max, ShouldEqual, 8000)
 			})
 		})

--- a/test/leak_test.go
+++ b/test/leak_test.go
@@ -17,8 +17,12 @@ func TestLeakOnShortRunning(t *testing.T) {
 			ds := SimpleCount()
 
 			Convey("It should not leak any goroutines", func() {
-				_, err := ds.RunAndCollect(testutils.ContextWithTimeout(), cluster)
+				result, err := ds.RunAndCollect(testutils.ContextWithTimeout(), cluster)
 				So(err, ShouldBeNil)
+
+				// Flush returned rows.
+				for _ = range result.Outputs() {
+				}
 			})
 		})
 	}))

--- a/test/map_test.go
+++ b/test/map_test.go
@@ -16,15 +16,22 @@ func TestMap(t *testing.T) {
 			Convey("It should run without error", func() {
 				result, err := ds.RunAndCollect(testutils.ContextWithTimeout(), cluster)
 				So(err, ShouldBeNil)
-				So(result.Outputs, ShouldHaveLength, 1000)
 
+				rowLen := 0
 				max := 0
-				for _, row := range result.Outputs {
+				for row := range result.Outputs() {
 					n := testutils.IntValue(row)
 					if n > max {
 						max = n
 					}
+
+					rowLen++
 				}
+				So(rowLen, ShouldEqual, 1000)
+
+				err = result.Err()
+				So(err, ShouldBeNil)
+
 				So(max, ShouldEqual, 8000)
 			})
 		})

--- a/test/sort_test.go
+++ b/test/sort_test.go
@@ -17,7 +17,10 @@ func TestSort(t *testing.T) {
 				rows, err := ds.RunAndCollect(testutils.ContextWithTimeout(), cluster)
 				So(err, ShouldBeNil)
 
-				res := testutils.GroupRowsByKey(rows.Outputs)
+				res := testutils.GroupRowsByKey(rows.Outputs())
+				err = rows.Err()
+				So(err, ShouldBeNil)
+
 				So(res, ShouldHaveLength, 3)
 
 				So(res["foo"], ShouldHaveLength, 1)

--- a/test/testutils/row_utils.go
+++ b/test/testutils/row_utils.go
@@ -19,9 +19,9 @@ func StringValues(rows []*lrdd.Row) (ss []string) {
 	return
 }
 
-func GroupRowsByKey(rows []*lrdd.Row) map[string][]*lrdd.Row {
+func GroupRowsByKey(rows <-chan *lrdd.Row) map[string][]*lrdd.Row {
 	grouped := make(map[string][]*lrdd.Row)
-	for _, row := range rows {
+	for row := range rows {
 		grouped[row.Key] = append(grouped[row.Key], row)
 	}
 	return grouped


### PR DESCRIPTION
- After this change, driver memory usage is reduced because it can handle the result row one by one.